### PR TITLE
fix: restore from Gibbs indices to measurement indices

### DIFF
--- a/cpp_ms_glmb_ukf/src/run_filter.hpp
+++ b/cpp_ms_glmb_ukf/src/run_filter.hpp
@@ -404,13 +404,21 @@ private:
                     if (update_hypcmp_tmp(ivec, 0) < 0) { // check death target in only one sensor
                         off_vec.push_back(ivec);
                         stemp += avqs(tindices(ivec));
-                    } else if (update_hypcmp_tmp(ivec, 0) == 0) {
-                        not_off_vec.push_back(ivec);
-                        stemp += avps(tindices(ivec));
-                    } else { // >0
+                    } else {
                         not_off_vec.push_back(ivec);
                         stemp += avps(tindices(ivec));
                     }
+                }
+                // Restore from Gibbs indices to measurement indices
+                for (int s = 0; s < mModel.N_sensors; s++) {
+                    for (int i : not_off_vec) {
+                        if (update_hypcmp_tmp(i, s) > 0) {
+                            update_hypcmp_tmp(i, s) = mindices[s](update_hypcmp_tmp(i, s));
+                        }
+                    }
+                }
+
+                for (int ivec = 0; ivec < update_hypcmp_tmp.rows(); ivec++) {
                     for (int s = 0; s < update_hypcmp_tmp.cols(); s++) {
                         int mIndex = update_hypcmp_tmp(ivec, s); // measurement index
                         if (mIndex > 0) {

--- a/ms_glmb_ukf/run_filter.py
+++ b/ms_glmb_ukf/run_filter.py
@@ -343,6 +343,11 @@ class GLMB:  # delta GLMB
             for hidx in range(len(uasses)):
                 update_hypcmp_tmp = uasses[hidx]
                 off_idx = update_hypcmp_tmp[:, 0] < 0
+
+                # Restore from Gibbs indices to measurement indices
+                for s in range(model.N_sensors):
+                    update_hypcmp_tmp[~off_idx, s] = mindices[s][update_hypcmp_tmp[~off_idx, s]]
+
                 aug_idx = np.column_stack((tindices, update_hypcmp_tmp))  # [tindices, 1 + update_hypcmp_tmp]
                 mis_idx = update_hypcmp_tmp == 0
                 det_idx = update_hypcmp_tmp > 0


### PR DESCRIPTION
This pull request introduces logic to restore measurement indices from internal Gibbs sampling indices in both the C++ and Python multi-sensor GLMB-UKF filter implementations. This ensures that after internal processing, the indices used for measurements correctly map back to the original measurement indices, improving consistency and correctness in downstream processing.

**Restoration of measurement indices:**

* In `cpp_ms_glmb_ukf/src/run_filter.hpp`, added a loop to convert Gibbs indices back to measurement indices for all relevant entries in `update_hypcmp_tmp` using the `mindices` mapping after hypothesis assignment.
* In `ms_glmb_ukf/run_filter.py`, inserted corresponding logic to restore measurement indices in `update_hypcmp_tmp` for all non-off (active) tracks using the `mindices` mapping.